### PR TITLE
Changed width to 190pt

### DIFF
--- a/RSBlurAlert/Classes/RSBlurAlertController.xib
+++ b/RSBlurAlert/Classes/RSBlurAlertController.xib
@@ -28,13 +28,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <visualEffectView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0W3-t7-ptU">
-                    <rect key="frame" x="102" y="219" width="170" height="229.5"/>
+                    <rect key="frame" x="92" y="209" width="190" height="249.5"/>
                     <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Buo-zq-CAl">
-                        <rect key="frame" x="0.0" y="0.0" width="170" height="229.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="190" height="249.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3aH-l6-xAg">
-                                <rect key="frame" x="30" y="20" width="110" height="110"/>
+                                <rect key="frame" x="30" y="20" width="130" height="130"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" white="0.0" alpha="0.75" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
@@ -42,13 +42,13 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Give details about this alert to the user here in details label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W77-Dr-FbQ">
-                                <rect key="frame" x="15" y="166.5" width="140" height="43"/>
+                                <rect key="frame" x="15" y="186.5" width="160" height="43"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ALERT" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UJp-sz-WRg">
-                                <rect key="frame" x="10" y="140" width="150" height="21.5"/>
+                                <rect key="frame" x="10" y="160" width="170" height="21.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                 <color key="textColor" white="0.0" alpha="0.75" colorSpace="deviceWhite"/>
                                 <nil key="highlightedColor"/>
@@ -69,7 +69,7 @@
                         </constraints>
                     </view>
                     <constraints>
-                        <constraint firstAttribute="width" constant="170" id="EsA-eq-i9K"/>
+                        <constraint firstAttribute="width" constant="190" id="EsA-eq-i9K"/>
                     </constraints>
                     <blurEffect style="light"/>
                     <userDefinedRuntimeAttributes>


### PR DESCRIPTION
Width of alert earlier was 170pt. Height is always dynamic according to how long and how many lines title and details take up. Upon taking into consideration the modification suggested in issue #1, I concluded that width of the alert should be increased to 190pt which makes it visually more readable and noticeable on all screen sizes, unlike previous where it was appearing to be a bit smaller in 4.7 inch onwards screen size. Fixed #1 